### PR TITLE
Feat/계정 설정 페이지 기능 구현

### DIFF
--- a/src/components/@shared/UI/Profile.tsx
+++ b/src/components/@shared/UI/Profile.tsx
@@ -6,8 +6,8 @@ import DropdownItem from "./DropdownItem";
 
 export default function Profile() {
   const router = useRouter();
-  const { logout } = useAuth();
-  const profileImageUrl = "/icons/icon-user.png";
+  const { logout, user } = useAuth();
+  const profileImageUrl = user?.image ?? "/icons/icon-user.png";
 
   // 드롭다운 항목 클릭 핸들러 정의 -> 수정 예정
   const handleMyHistoryClick = () => {

--- a/src/components/PageComponents/account/ChangePasswordModal.tsx
+++ b/src/components/PageComponents/account/ChangePasswordModal.tsx
@@ -91,8 +91,7 @@ export default function ChangePasswordModal() {
       updatePasswordMutation.mutate(formData);
     }
   };
-  console.log(formData);
-  console.log(formErrors);
+
   return (
     <Modal isOpen={isOpen} onClose={closeChangePasswordModal}>
       <div className="h-auto w-[24rem] overflow-x-hidden px-6 py-8">

--- a/src/components/PageComponents/account/ChangePasswordModal.tsx
+++ b/src/components/PageComponents/account/ChangePasswordModal.tsx
@@ -1,0 +1,157 @@
+import Button from "@/components/@shared/UI/Button";
+import Input from "@/components/@shared/UI/Input";
+import InputLabel from "@/components/@shared/UI/InputLabel";
+import Modal from "@/components/@shared/UI/Modal/Modal";
+import updatePassword from "@/core/api/user/updatePassword";
+import { UpdatePasswordForm } from "@/core/dtos/user/auth";
+import useModalStore from "@/lib/hooks/stores/modalStore";
+import { validatePassword } from "@/lib/utils/validation";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+
+interface FormErrors {
+  password: string | undefined;
+  passwordConfirmation: string | undefined;
+}
+
+export default function ChangePasswordModal() {
+  const modalName = "changePasswordModal";
+  const isOpen = useModalStore((state) => state.modals[modalName] || false);
+  const closeModal = useModalStore((state) => state.closeModal);
+
+  const [formData, setFormData] = useState({
+    password: "",
+    passwordConfirmation: "",
+  });
+  const [formErrors, setFormErrors] = useState<FormErrors>({
+    password: undefined,
+    passwordConfirmation: undefined,
+  });
+
+  const closeChangePasswordModal = () => {
+    closeModal("changePasswordModal");
+    setFormData({ password: "", passwordConfirmation: "" });
+    setFormErrors({ password: undefined, passwordConfirmation: undefined });
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prevData) => ({ ...prevData, [name]: value }));
+  };
+
+  const handleBlur = (target: HTMLInputElement) => {
+    let error = "";
+    switch (target.name) {
+      case "password":
+        error = validatePassword(target.value) ?? "";
+        break;
+      case "passwordConfirmation":
+        if (!target.value) {
+          error = "새 비밀번호를 다시 한 번 입력해주세요.";
+        } else if (target.value !== formData.password) {
+          error = "비밀번호가 일치하지 않습니다.";
+        }
+        break;
+      default:
+        break;
+    }
+    setFormErrors((prevErrors) => ({ ...prevErrors, [target.name]: error }));
+  };
+
+  const validateForm = () => {
+    const newErrors = {
+      password: validatePassword(formData.password ?? ""),
+      passwordConfirmation:
+        formData.password !== formData.passwordConfirmation
+          ? "비밀번호가 일치하지 않습니다."
+          : undefined,
+    };
+    setFormErrors(newErrors);
+    return !Object.values(newErrors).some((error) => error !== undefined);
+  };
+
+  const updatePasswordMutation = useMutation({
+    mutationFn: (newFormData: UpdatePasswordForm) =>
+      updatePassword(newFormData),
+    onSuccess: () => {
+      closeChangePasswordModal();
+    },
+    onError: (error) => {
+      console.error("비밀번호 변경 중 오류 발생:", error);
+    },
+  });
+
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateForm()) {
+      return;
+    }
+
+    if (formData.password && formData.passwordConfirmation) {
+      updatePasswordMutation.mutate(formData);
+    }
+  };
+  console.log(formData);
+  console.log(formErrors);
+  return (
+    <Modal isOpen={isOpen} onClose={closeChangePasswordModal}>
+      <div className="h-auto w-[24rem] overflow-x-hidden px-6 py-8">
+        <h2 className="pb-3 text-center text-text-lg text-text-primary">
+          비밀번호 변경하기
+        </h2>
+        <form
+          className="flex flex-col items-center gap-6"
+          onSubmit={handleFormSubmit}
+        >
+          <InputLabel className="text-md text-text-primary" label="새 비밀번호">
+            <Input
+              name="password"
+              type="password"
+              value={formData.password}
+              isValid={!formErrors.password}
+              errorMessage={formErrors.password}
+              className="w-[21rem]"
+              placeholder="새 비밀번호를 입력해주세요."
+              onChange={handleChange}
+              onBlur={(e) => handleBlur(e.target)}
+            />
+          </InputLabel>
+          <InputLabel
+            className="text-md text-text-primary"
+            label="새 비밀번호 확인"
+          >
+            <Input
+              name="passwordConfirmation"
+              type="password"
+              value={formData.passwordConfirmation}
+              isValid={!formErrors.passwordConfirmation}
+              errorMessage={formErrors.passwordConfirmation}
+              className="w-[21rem]"
+              placeholder="새 비밀번호를 다시 한 번 입력해주세요."
+              onChange={handleChange}
+              onBlur={(e) => handleBlur(e.target)}
+            />
+          </InputLabel>
+          <div className="mt-4 flex w-full justify-between gap-2">
+            <Button
+              variant="outlined"
+              size="large"
+              onClick={closeChangePasswordModal}
+              className="w-1/2"
+            >
+              닫기
+            </Button>
+            <Button
+              variant="solid"
+              size="large"
+              onClick={handleFormSubmit}
+              className="w-1/2"
+            >
+              변경하기
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/PageComponents/account/DeleteAccountModal.tsx
+++ b/src/components/PageComponents/account/DeleteAccountModal.tsx
@@ -1,0 +1,76 @@
+import Modal from "@/components/@shared/UI/Modal/Modal";
+import Image from "next/image";
+import useModalStore from "@/lib/hooks/stores/modalStore";
+import Button from "@/components/@shared/UI/Button";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+import deleteUser from "@/core/api/user/deleteUser";
+import { useRouter } from "next/router";
+import { removeTokens } from "@/lib/utils/tokenStorage";
+
+export default function DeleteAccountModal() {
+  const router = useRouter();
+  const modalName = "deleteAccountModal";
+  const isOpen = useModalStore((state) => state.modals[modalName] || false);
+  const closeModal = useModalStore((state) => state.closeModal);
+
+  const closeDeleteModal = () => {
+    closeModal("deleteAccountModal");
+  };
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteUser(),
+    onSuccess: () => {
+      closeDeleteModal();
+      router.push("/login");
+      removeTokens();
+      toast.success("회원 탈퇴가 완료됐습니다!");
+    },
+    onError: (error) => {
+      console.error("Delete failed:", error);
+      toast.error("에러가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    },
+  });
+
+  const handleDeleteAccount = () => {
+    deleteMutation.mutate();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={() => closeDeleteModal()}>
+      <div className="flex w-80 flex-col items-center justify-between font-medium">
+        <Image
+          src="/icons/icon-alert.svg"
+          width={24}
+          height={24}
+          alt="경고 아이콘"
+        />
+        <p className="mt-4 text-center">회원 탈퇴를 진행하시겠어요?</p>
+        <p className="mt-2 text-center text-text-md text-text-secondary">
+          그룹장으로 있는 그룹은 자동으로 삭제되고,
+          <br />
+          모든 그룹에서 나가집니다.
+        </p>
+
+        <div className="mt-6 flex w-full gap-2">
+          <Button
+            variant="outlined"
+            size="large"
+            className="[&&]:bg-background-inverse"
+            onClick={closeDeleteModal}
+          >
+            닫기
+          </Button>
+          <Button
+            variant="solid"
+            size="large"
+            className="[&&]:bg-status-danger"
+            onClick={handleDeleteAccount}
+          >
+            삭제하기
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/core/api/user/updatePassword.ts
+++ b/src/core/api/user/updatePassword.ts
@@ -1,0 +1,16 @@
+import {
+  UpdatePasswordForm,
+  UpdatePasswordResponse,
+} from "@/core/dtos/user/auth";
+import { AxiosError, AxiosResponse } from "axios";
+import axiosInstance from "../axiosInstance";
+
+export default async function updatePassword(
+  updatePasswordForm: UpdatePasswordForm,
+) {
+  const res: AxiosResponse<UpdatePasswordResponse> = await axiosInstance
+    .patch("user/password", updatePasswordForm)
+    .catch((e: AxiosError) => Promise.reject(e.response));
+
+  return res.data;
+}

--- a/src/core/dtos/user/auth.ts
+++ b/src/core/dtos/user/auth.ts
@@ -3,7 +3,6 @@ import { Membership } from "./membership";
 export interface UserBase {
   id: number;
 
-
   teamId: string;
 
   email: string;
@@ -13,7 +12,6 @@ export interface UserBase {
   image: string;
 
   createdAt: string;
-
 
   updatedAt: string;
 }
@@ -51,5 +49,15 @@ export interface UpdateUserForm {
 }
 
 export interface UpdateUserResponse {
+  message: string;
+}
+
+export interface UpdatePasswordForm {
+  passwordConfirmation: string;
+
+  password: string;
+}
+
+export interface UpdatePasswordResponse {
   message: string;
 }

--- a/src/core/dtos/user/auth.ts
+++ b/src/core/dtos/user/auth.ts
@@ -43,7 +43,7 @@ export interface LoginForm {
 export interface LoginResponse extends Tokens, UserBase {}
 
 export interface UpdateUserForm {
-  nickname?: string;
+  nickname?: string | undefined;
 
   image: string;
 }

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/core/context/AuthProvider";
 import AuthHeader from "@/components/@shared/UI/AuthHeader";
 import useModalStore from "@/lib/hooks/stores/modalStore";
 import DeleteAccountModal from "@/components/PageComponents/account/DeleteAccountModal";
+import ChangePasswordModal from "@/components/PageComponents/account/ChangePasswordModal";
 
 export default function AccountSettings() {
   const { user } = useAuth(true);
@@ -36,6 +37,10 @@ export default function AccountSettings() {
 
   const openDeleteAccountModal = () => {
     openModal("deleteAccountModal");
+  };
+
+  const openChangePasswordModal = () => {
+    openModal("changePasswordModal");
   };
 
   return (
@@ -91,10 +96,11 @@ export default function AccountSettings() {
             <InputLabel label="비밀번호">
               <Input
                 type="password"
-                placeholder="비밀번호"
+                placeholder="●●●●●●●●●"
                 disabled
                 className="relative w-full rounded-xl bg-gray-800 px-4 py-2 text-white"
                 buttonContent="변경하기"
+                onButtonClick={openChangePasswordModal}
                 buttonClassName="absolute top-1/2 transform -translate-y-1/2 right-3 flex items-center justify-center gap-2.5 rounded-xl text-center font-[Pretendard] font-semibold transition-all duration-200 h-8 w-auto min-w-[80px] text-sm leading-[17px]    text-text-primary [&&]:bg-brand-primary
               [&&]:hover:bg-interaction-hover
               [&&]:active:bg-interaction-pressed"
@@ -127,6 +133,7 @@ export default function AccountSettings() {
         </div>
       </div>
       <DeleteAccountModal />
+      <ChangePasswordModal />
     </div>
   );
 }

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -9,11 +9,17 @@ import AuthHeader from "@/components/@shared/UI/AuthHeader";
 import useModalStore from "@/lib/hooks/stores/modalStore";
 import DeleteAccountModal from "@/components/PageComponents/account/DeleteAccountModal";
 import ChangePasswordModal from "@/components/PageComponents/account/ChangePasswordModal";
+import { useMutation } from "@tanstack/react-query";
+import updateUser from "@/core/api/user/updateUser";
+import { UpdateUserForm } from "@/core/dtos/user/auth";
+import { useRouter } from "next/router";
+import React, { useState } from "react";
 
 export default function AccountSettings() {
+  const router = useRouter();
   const { user } = useAuth(true);
   const openModal = useModalStore((state) => state.openModal);
-  const defaultProfileImage = "/icons/icon-addProfile.png";
+  const defaultProfileImage = user?.image ?? "/icons/icon-addProfile.png";
   const {
     fileInputValue,
     file,
@@ -21,17 +27,34 @@ export default function AccountSettings() {
     getImageUrl,
     imagePreview,
   } = useImageUpload(defaultProfileImage);
+  const [nickName, setNickName] = useState(user?.nickname);
 
   const handleProfileClick = () => {
     document.getElementById("fileInput")?.click();
   };
 
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setNickName(value);
+  };
+
+  const updateUserMutation = useMutation({
+    mutationFn: (newFormData: UpdateUserForm) => updateUser(newFormData),
+    onSuccess: () => {
+      router.push("/");
+    },
+    onError: (error) => {
+      console.error("계정 업데이트 중 오류 발생:", error);
+    },
+  });
+
   const handleUploadClick = async () => {
     if (!file) return;
     try {
-      await getImageUrl(file);
+      const imageUrl = await getImageUrl(file);
+      updateUserMutation.mutate({ image: imageUrl, nickname: nickName });
     } catch (e) {
-      alert("이미지 업로드 실패");
+      alert("계정 업데이트 실패");
     }
   };
 
@@ -81,6 +104,9 @@ export default function AccountSettings() {
                 type="text"
                 placeholder={user?.nickname}
                 className="w-full rounded-xl bg-gray-800 px-4 py-2 text-white"
+                onChange={handleInputChange}
+                value={nickName}
+                name="nickname"
               />
             </InputLabel>
 

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -1,12 +1,17 @@
-import SetupHeader from "@/components/@shared/UI/SetupHeader";
 import FileInput from "@/components/@shared/UI/FileInput";
 import Input from "@/components/@shared/UI/Input";
 import Button from "@/components/@shared/UI/Button";
 import Image from "next/image";
 import useImageUpload from "@/lib/hooks/useImageUpload";
 import InputLabel from "@/components/@shared/UI/InputLabel";
+import { useAuth } from "@/core/context/AuthProvider";
+import AuthHeader from "@/components/@shared/UI/AuthHeader";
+import useModalStore from "@/lib/hooks/stores/modalStore";
+import DeleteAccountModal from "@/components/PageComponents/account/DeleteAccountModal";
 
 export default function AccountSettings() {
+  const { user } = useAuth(true);
+  const openModal = useModalStore((state) => state.openModal);
   const defaultProfileImage = "/icons/icon-addProfile.png";
   const {
     fileInputValue,
@@ -29,9 +34,13 @@ export default function AccountSettings() {
     }
   };
 
+  const openDeleteAccountModal = () => {
+    openModal("deleteAccountModal");
+  };
+
   return (
     <div>
-      <SetupHeader />
+      <AuthHeader />
       <div className="mt-[84px] flex w-full justify-center lg:mt-[100px]">
         <div className="flex w-full max-w-[792px] flex-col items-start gap-y-5 px-4 sm:px-6 md:px-6">
           <h2 className="text-lg font-bold">계정 설정</h2>
@@ -65,7 +74,7 @@ export default function AccountSettings() {
             <InputLabel label="이름">
               <Input
                 type="text"
-                placeholder="이름"
+                placeholder={user?.nickname}
                 className="w-full rounded-xl bg-gray-800 px-4 py-2 text-white"
               />
             </InputLabel>
@@ -73,7 +82,7 @@ export default function AccountSettings() {
             <InputLabel label="이메일">
               <Input
                 type="email"
-                placeholder="이메일"
+                placeholder={user?.email}
                 className="w-full rounded-xl bg-gray-800 px-4 py-2 text-white"
                 disabled
               />
@@ -83,6 +92,7 @@ export default function AccountSettings() {
               <Input
                 type="password"
                 placeholder="비밀번호"
+                disabled
                 className="relative w-full rounded-xl bg-gray-800 px-4 py-2 text-white"
                 buttonContent="변경하기"
                 buttonClassName="absolute top-1/2 transform -translate-y-1/2 right-3 flex items-center justify-center gap-2.5 rounded-xl text-center font-[Pretendard] font-semibold transition-all duration-200 h-8 w-auto min-w-[80px] text-sm leading-[17px]    text-text-primary [&&]:bg-brand-primary
@@ -101,18 +111,22 @@ export default function AccountSettings() {
                 저장하기
               </Button>
             </div>
-            <button className="mt-2 flex items-center gap-2 text-point-red">
-              <Image
-                src="/icons/icon-secession.png"
-                width={24}
-                height={24}
-                alt="회원 탈퇴하기"
-              />
-              회원 탈퇴하기
-            </button>
           </form>
+          <button
+            className="mt-2 flex items-center gap-2 text-point-red"
+            onClick={openDeleteAccountModal}
+          >
+            <Image
+              src="/icons/icon-secession.png"
+              width={24}
+              height={24}
+              alt="회원 탈퇴하기"
+            />
+            회원 탈퇴하기
+          </button>
         </div>
       </div>
+      <DeleteAccountModal />
     </div>
   );
 }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -11,8 +11,12 @@ import { validatePassword, validateEmail } from "@/lib/utils/validation";
 import { SignupRequestDto } from "@/core/dtos/auth/authDto";
 import { useMutation } from "@tanstack/react-query";
 import { signup } from "@/core/api/auth/authApi";
+import { useRouter } from "next/router";
+import { useAuth } from "@/core/context/AuthProvider";
 
 export default function Signup() {
+  const router = useRouter();
+  const { login } = useAuth();
   const [showPassword, setShowPassword] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -102,8 +106,11 @@ export default function Signup() {
       };
 
       try {
+        const { email, password } = formData;
         setIsSubmitting(true);
         await signupMutate(signupData);
+        await login({ email, password });
+        router.push("/");
       } catch (error: unknown) {
         console.error("에러 :", error);
         if (error instanceof Error) {


### PR DESCRIPTION
## 📝 작업 내용 설명

- 계정 설정 페이지: 회원 탈퇴, 비밀번호 변경, 계정 업데이트 기능을 구현했습니다.

## 📷 스크린샷 (선택)
### 회원 탈퇴
![image](https://github.com/user-attachments/assets/f7c8738d-e639-4a79-a1fc-fd18b5408e7c)
### 비밀번호 변경
![image](https://github.com/user-attachments/assets/bf86dfca-111b-4be1-8ef8-4a95b37baa31)
### 계정 업데이트
![image](https://github.com/user-attachments/assets/424729f1-a38a-4b0e-9a4b-edee2b4f705c)


